### PR TITLE
Fix a sniff-fix bug and update readme with manual usage instructions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,6 @@
+language: php
+php:
+  - 5.6
+install: composer install --prefer-source
+script:
+  - make sniff

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,15 @@
+SE_STANDARD_PATH="`pwd`/src/SocialEngine/SnifferRules/Standard/"
+PHPCS=php ./vendor/bin/phpcs
+PHPCBF=php ./vendor/bin/phpcbf
+INSTALLED=$(shell ${PHPCS} -i)
+
+sniff: check-standard
+	${PHPCS} --colors --standard=SocialEngine --ignore=src/SocialEngine/SnifferRules/Standard src
+
+sniff-fix: check-standard
+	${PHPCBF} --colors --standard=SocialEngine --ignore=src/SocialEngine/SnifferRules/Standard src
+
+check-standard: 
+ifeq (,$(findstring SocialEngine, $(INSTALLED)))
+	${PHPCS} --config-set installed_paths ${SE_STANDARD_PATH}
+endif

--- a/README.md
+++ b/README.md
@@ -1,16 +1,15 @@
 # phpcs 2.0+ Laravel 4/5 Command
+[![Build Status](https://travis-ci.org/SocialEngine/sniffer-rules.svg?branch=master)](https://travis-ci.org/SocialEngine/sniffer-rules)
+[![Latest Stable Version](https://poser.pugx.org/SocialEngine/sniffer-rules/version.png)](https://packagist.org/packages/SocialEngine/sniffer-rules)
+[![License](https://poser.pugx.org/SocialEngine/sniffer-rules/license.svg)](https://packagist.org/packages/SocialEngine/sniffer-rules)
 
 This is a [Laravel](http://laravel.com/) 4/5 package that hooks up 
-[SquizLabs CodeSniffer 2.0](https://github.com/squizlabs/PHP_CodeSniffer) 
-into Laravel-based apps.
+[SquizLabs CodeSniffer 2](https://github.com/squizlabs/PHP_CodeSniffer) 
+into Laravel-based apps. It can also be used manually, so read on.
 
 Detect violations of a defined coding standard. It helps your code remain 
 clean and consistent. Available options are: **PSR2**, **PSR1**, **Zend**, 
 **PEAR**, **Squiz**, **PHPCS** and **SocialEngine**.
-
-Note: This is a hybrid package that works with both Laravel 4 and 5.
-
-The only limitation for L4 is that you have to create your config manually.
 
 ### Setup
 
@@ -20,8 +19,11 @@ Require this package in composer:
 $ composer require socialengine/sniffer-rules
 ```
 
+#### Laravel 4/5
+
 In your `config/app.php` add `'SocialEngine\SnifferRules\ServiceProvider'` 
 to `$providers` array:
+
 ```php
 'providers' => [
     'Illuminate\Foundation\Providers\ArtisanServiceProvider',
@@ -31,23 +33,59 @@ to `$providers` array:
 
 ],
 ```
-**Laravel 5**: Publish the configuration file:
+#### Laravel 5: Publish the configuration file
 
-    $ php artisan vendor:publish
+```bash
+$ php artisan vendor:publish
+```
 
-**Laravel 4**: Manually create `app/config/sniffer-rules.php` by copying 
-[config](src/SocialEngine/SnifferRules/config/config.php)
+#### Laravel 4: Manually create config
+
+Copy [config](src/SocialEngine/SnifferRules/config/config.php) to 
+`app/config/sniffer-rules.php` 
 
 Edit configuration file `config/sniffer-rules.php` to tweak the sniffer behavior.
 
-### Usage
+#### Manual
 
-    $ php artisan sniff
+Install our _Standard_ by configuring **PHP_CodeSniffer** to look for it. 
+
+```bash
+$ php ./vendor/bin/phpcs --config-set installed_paths ./vendor/socialengine/src/Socialengine/SnifferRules/Standard/
+```
+
+### Usage
+#### Laravel
+```bash
+$ php artisan sniff
+```
     
 To run the sniffer in a CI environment, the `-n` option should be set to remove
 interaction:
 
-    $ php artisan sniff -n
+```
+$ php artisan sniff -n
+```
+
+#### Manual
+
+```bash
+$ php ./vendor/bin/phpcs --standard=SocialEngine path/to/code 
+```
+
+It's encouraged to add a [`Makefile`](Makefile) to your project that makes it 
+trivial for other developers. Use `Makefile` in this directory and adjust as 
+needed to fit your project requirements.
+
+### Travis
+
+In combination with the [`Makefile`](Makefile), Travis has issues finding the
+standard, we had to add a `before_script` to make it work. See 
+[Unum](https://github.com/SocialEngine/Unum) repo for example.
+
+```yml
+before_script: php ./vendor/bin/phpcs --config-set installed_paths "`pwd`/vendor/socialengine/sniffer-rules/src/SocialEngine/SnifferRules/Standard/"
+```
 
 ## SocialEngine Coding Standards
 

--- a/src/SocialEngine/SnifferRules/Command/SniffCommand.php
+++ b/src/SocialEngine/SnifferRules/Command/SniffCommand.php
@@ -172,7 +172,7 @@ class SniffCommand extends Command
         }
 
 
-        foreach($options as $name => $value) {
+        foreach ($options as $name => $value) {
             if ($value === true) {
                 $commandParts[] = '--' . $name;
             } elseif (is_array($value)) {
@@ -197,7 +197,7 @@ class SniffCommand extends Command
     {
         $validOptions = [];
 
-        foreach($this->getOptions() as $option) {
+        foreach ($this->getOptions() as $option) {
             $key = $option[0];
             $validOptions[$key] = $this->option($key);
         }

--- a/src/SocialEngine/SnifferRules/Command/SniffCommand.php
+++ b/src/SocialEngine/SnifferRules/Command/SniffCommand.php
@@ -166,7 +166,7 @@ class SniffCommand extends Command
         }
         unset($options['runtime-set']);
 
-        if ($options['colors'] === false) {
+        if (isset($options['colors']) && $options['colors'] === false) {
             // don't pass --colors= if its false
             unset($options['colors']);
         }

--- a/src/SocialEngine/SnifferRules/ServiceProvider.php
+++ b/src/SocialEngine/SnifferRules/ServiceProvider.php
@@ -22,12 +22,11 @@ class ServiceProvider extends LaravelServiceProvider
         $app = $this->app;
 
         if ($app::VERSION > '5.0') {
-
             $this->publishes([
                 __DIR__ . '/config/config.php' => config_path('sniffer-rules.php'),
             ]);
         } else {
-            $this->package('socialengine/sniffer-rules', null,  __DIR__);
+            $this->package('socialengine/sniffer-rules', null, __DIR__);
         }
     }
 

--- a/src/SocialEngine/SnifferRules/Standard/SocialEngine/Sniffs/WhiteSpace/OperatorSpacingSniff.php
+++ b/src/SocialEngine/SnifferRules/Standard/SocialEngine/Sniffs/WhiteSpace/OperatorSpacingSniff.php
@@ -51,8 +51,7 @@ class SocialEngine_Sniffs_WhiteSpace_OperatorSpacingSniff implements PHP_CodeSni
                 } else {
                     if (strlen($tokens[($stackPtr - 1)]['content']) !== 1) {
                         $found = strlen($tokens[($stackPtr - 1)]['content']);
-                        $error = sprintf('Expected 1 space before "&" operator; %s found'
-                          , $found);
+                        $error = sprintf('Expected 1 space before "&" operator; %s found', $found);
 
                         $phpcsFile->addError($error, $stackPtr, 'SpacingBeforeAmp');
                     }
@@ -65,8 +64,7 @@ class SocialEngine_Sniffs_WhiteSpace_OperatorSpacingSniff implements PHP_CodeSni
                 } else {
                     if (strlen($tokens[($stackPtr + 1)]['content']) !== 1) {
                         $found = strlen($tokens[($stackPtr + 1)]['content']);
-                        $error = sprintf('Expected 1 space after "&" operator; %s found'
-                          , $found);
+                        $error = sprintf('Expected 1 space after "&" operator; %s found', $found);
 
                         $phpcsFile->addError($error, $stackPtr, 'SpacingAfterAmp');
                     }
@@ -129,13 +127,12 @@ class SocialEngine_Sniffs_WhiteSpace_OperatorSpacingSniff implements PHP_CodeSni
             if ($tokens[($stackPtr - 1)]['code'] !== T_WHITESPACE) {
                 $error = "Expected 1 space before \"$operator\"; 0 found";
                 $phpcsFile->addError($error, $stackPtr, 'NoSpaceBefore');
-            } else if (strlen($tokens[($stackPtr - 1)]['content']) !== 1) {
+            } elseif (strlen($tokens[($stackPtr - 1)]['content']) !== 1) {
                 // Don't throw an error for assignments, because other standards allow
                 // multiple spaces there to align multiple assignments.
                 if (in_array($operatorCode, PHP_CodeSniffer_Tokens::$assignmentTokens) === false) {
                     $found = strlen($tokens[($stackPtr - 1)]['content']);
-                    $error = sprintf('Expected 1 space before "%s"; %s found'
-                      , $operator, $found);
+                    $error = sprintf('Expected 1 space before "%s"; %s found', $operator, $found);
 
                     $phpcsFile->addError($error, $stackPtr, 'SpacingBefore');
                 }
@@ -144,10 +141,9 @@ class SocialEngine_Sniffs_WhiteSpace_OperatorSpacingSniff implements PHP_CodeSni
             if ($tokens[($stackPtr + 1)]['code'] !== T_WHITESPACE) {
                 $error = "Expected 1 space after \"$operator\"; 0 found";
                 $phpcsFile->addError($error, $stackPtr, 'NoSpaceAfter');
-            } else if (strlen($tokens[($stackPtr + 1)]['content']) !== 1) {
+            } elseif (strlen($tokens[($stackPtr + 1)]['content']) !== 1) {
                 $found = strlen($tokens[($stackPtr + 1)]['content']);
-                $error = sprintf('Expected 1 space after "%s"; %s found'
-                  , $operator, $found);
+                $error = sprintf('Expected 1 space after "%s"; %s found', $operator, $found);
 
                 $phpcsFile->addError($error, $stackPtr, 'SpacingAfter');
             }


### PR DESCRIPTION
### What is the problem / feature ?

- `php artisan sniff` automatic issue fixing was broken due to an unset option.
- the instructions were a bit outdated and did not include instructions on how to run this command manually.
- We were not eating our own dogfood. 

### How did it get fixed / implemented ?

- fixed the bug in 4bdfd19
- added instructions and `Makefile` along a `travis.yml`
- Fixed self-found sniff violations.
