### PR TITLE
Lumen/Laravel 5.5 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
-# phpcs 2.0+ Laravel 4/5 Command
+# phpcs 2.0+ Laravel 5, Lumen 5 Command
 [![Build Status](https://travis-ci.org/SocialEngine/sniffer-rules.svg?branch=master)](https://travis-ci.org/SocialEngine/sniffer-rules)
 [![Latest Stable Version](https://poser.pugx.org/SocialEngine/sniffer-rules/version.png)](https://packagist.org/packages/SocialEngine/sniffer-rules)
 [![License](https://poser.pugx.org/SocialEngine/sniffer-rules/license.svg)](https://packagist.org/packages/SocialEngine/sniffer-rules)
 
-This is a [Laravel](http://laravel.com/) 4/5 package that hooks up 
+This is a [Laravel](http://laravel.com/) 5 package that hooks up 
 [SquizLabs CodeSniffer 2](https://github.com/squizlabs/PHP_CodeSniffer) 
 into Laravel-based apps. It can also be used manually, so read on.
 
@@ -19,7 +19,7 @@ Require this package in composer:
 $ composer require socialengine/sniffer-rules
 ```
 
-#### Laravel 4/5
+#### Laravel 5
 
 In your `config/app.php` add `'SocialEngine\SnifferRules\ServiceProvider'` 
 to `$providers` array:
@@ -38,13 +38,6 @@ to `$providers` array:
 ```bash
 $ php artisan vendor:publish
 ```
-
-#### Laravel 4: Manually create config
-
-Copy [config](src/SocialEngine/SnifferRules/config/config.php) to 
-`app/config/sniffer-rules.php` 
-
-Edit configuration file `config/sniffer-rules.php` to tweak the sniffer behavior.
 
 #### Manual
 

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "socialengine/sniffer-rules",
-    "description": "A Laravel 4 and Laravel 5 SquizLabs Code Sniffer 2.0 artisan command. Detect violations of a defined coding standard. It helps your code remains clean and consistent.",
-    "keywords": ["laravel", "laravel 4", "laravel 5", "lumen", "code sniffer", "squizlabs", "phpcs", "artisan", "cli"],
+    "description": "A Lumen 5 and Laravel 5 SquizLabs Code Sniffer 2.0 artisan command. Detect violations of a defined coding standard. It helps your code remains clean and consistent.",
+    "keywords": ["laravel", "laravel 5", "lumen", "lumen 5", "code sniffer", "squizlabs", "phpcs", "artisan", "cli"],
     "homepage": "https://github.com/socialengine/sniffer-rules",
     "license": "MIT",
     "authors": [

--- a/src/SocialEngine/SnifferRules/Command/SniffCommand.php
+++ b/src/SocialEngine/SnifferRules/Command/SniffCommand.php
@@ -91,6 +91,16 @@ class SniffCommand extends Command
     }
 
     /**
+     * Forward compatibility with Laravel/Lumen 5.5
+     *
+     * @return mixed
+     */
+    public function handle()
+    {
+        return $this->fire();
+    }
+
+    /**
      * Get the console command arguments.
      *
      * @return array

--- a/src/SocialEngine/SnifferRules/Command/SniffCommand.php
+++ b/src/SocialEngine/SnifferRules/Command/SniffCommand.php
@@ -84,7 +84,6 @@ class SniffCommand extends Command
             passthru($command, $exitCode);
 
             $this->info('Done.');
-
         }
 
         return $exitCode;


### PR DESCRIPTION
Lumen and Laravel v 5.5 removed "fire" checking for method name in commands. Now they always call `handle`, which did not exist in our command. This PR fixes it.

See #14 